### PR TITLE
Auto-register Composition in Root.tsx on "New Folder"

### DIFF
--- a/scripts/server/create-project.ts
+++ b/scripts/server/create-project.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync } from "fs";
 import { IncomingMessage, ServerResponse } from "http";
 import path from "path";
+import { registerComposition } from "./register-composition";
 
 export const createProject = async (
   req: IncomingMessage,
@@ -46,11 +47,25 @@ export const createProject = async (
 
   try {
     mkdirSync(finalPath);
+
+    let registrationMessage = "";
+    try {
+      const result = registerComposition({ rootDir, projectName });
+      if (result.registered) {
+        registrationMessage =
+          " Composition registered in remotion/Root.tsx.";
+      } else if (result.reason && result.reason !== "Composition already exists") {
+        registrationMessage = ` Folder created but composition was not registered: ${result.reason}. Edit remotion/Root.tsx manually to add it.`;
+      }
+    } catch (err) {
+      registrationMessage = ` Folder created but composition registration threw: ${(err as Error).message}.`;
+    }
+
     res.statusCode = 201;
     res.write(
       JSON.stringify({
         success: true,
-        message: `Project "${projectName}" created successfully.`,
+        message: `Project "${projectName}" created successfully.${registrationMessage}`,
       }),
     );
     return res.end();

--- a/scripts/server/register-composition.ts
+++ b/scripts/server/register-composition.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import path from "path";
+
+const ROOT_RELATIVE_PATH = path.join("remotion", "Root.tsx");
+const TEMPLATE_COMPOSITION_ID = "empty";
+
+const findEmptyCompositionBlock = (src: string): string | null => {
+  const idMarker = `id="${TEMPLATE_COMPOSITION_ID}"`;
+  const idIndex = src.indexOf(idMarker);
+  if (idIndex === -1) {
+    return null;
+  }
+
+  const startIndex = src.lastIndexOf("<Composition", idIndex);
+  if (startIndex === -1) {
+    return null;
+  }
+
+  const endMarker = "/>";
+  const endIndex = src.indexOf(endMarker, idIndex);
+  if (endIndex === -1) {
+    return null;
+  }
+
+  return src.slice(startIndex, endIndex + endMarker.length);
+};
+
+export const registerComposition = ({
+  rootDir,
+  projectName,
+}: {
+  rootDir: string;
+  projectName: string;
+}): { registered: boolean; reason?: string } => {
+  const rootPath = path.join(rootDir, ROOT_RELATIVE_PATH);
+
+  if (!existsSync(rootPath)) {
+    return { registered: false, reason: "Root.tsx not found" };
+  }
+
+  const src = readFileSync(rootPath, "utf-8");
+
+  if (src.includes(`id="${projectName}"`)) {
+    return { registered: false, reason: "Composition already exists" };
+  }
+
+  const emptyBlock = findEmptyCompositionBlock(src);
+  if (!emptyBlock) {
+    return {
+      registered: false,
+      reason: 'Could not find <Composition id="empty"> to clone',
+    };
+  }
+
+  const defaultVideoScene = `          scenes: [
+            {
+              type: "videoscene" as const,
+              webcamPosition: "bottom-right" as const,
+              endOffset: 0,
+              transitionToNextScene: false,
+              newChapter: "",
+              stopChapteringAfterThis: false,
+              music: "none" as const,
+              startOffset: 0,
+              bRolls: [],
+            },
+          ],`;
+
+  const cloned = emptyBlock
+    .replace(
+      `id="${TEMPLATE_COMPOSITION_ID}"`,
+      `id="${projectName}"`,
+    )
+    .replace("          scenes: [],", defaultVideoScene);
+
+  const newSrc = src.replace(emptyBlock, `${cloned}\n      ${emptyBlock}`);
+
+  writeFileSync(rootPath, newSrc, "utf-8");
+  return { registered: true };
+};


### PR DESCRIPTION
Closes remotion-dev/remotion#7411

Patches `remotion/Root.tsx` automatically when the existing `POST /api/create-folder` endpoint succeeds:

1. Find the `<Composition id="empty">` block.
2. Clone it with the new folder name as the id.
3. Pre-populate `scenes` with one default `videoscene` so the just-recorded take is immediately playable.
4. Inject the cloned block above the `empty` composition.

Idempotent, falls back to a clear response message if `Root.tsx` can't be parsed, no new deps.

Tested end-to-end: new folder → record → save → composition appears in Studio with the take playing, zero manual code edits.